### PR TITLE
Fix :  Redirect to the rust squad in daily dev

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -30,7 +30,7 @@ export default function Header() {
 
   return (
     <header className="flex justify-end items-center p-4 space-x-4">
-      <a href="https://daily.dev" target="_blank" rel="noopener noreferrer" className="text-2xl" title="Rustdevs on daily.dev">
+      <a href="https://app.daily.dev/squads/rustdevs" target="_blank" rel="noopener noreferrer" className="text-2xl" title="Rustdevs on daily.dev">
         <Image src="/rust_lgo_720.png" alt="daily.dev" width={24} height={24} />
       </a>
       <a href="https://github.com/FrancescoXX/rustcrab" target="_blank" rel="noopener noreferrer" className="text-2xl" title="GitHub repository">


### PR DESCRIPTION
Fixes : #9 

This PR fixes R icon at the top right redirects to just `daily.dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the "Rustdevs on daily.dev" hyperlink in the header to point to the new URL: `https://app.daily.dev/squads/rustdevs`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->