### PR TITLE
(feat) : Add Google Analytics to Rust Crab

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { Inter } from "next/font/google";
 import { Roboto } from 'next/font/google';
 import Head from 'next/head';
 import "./globals.css";
+import Script from "next/script";
 
 const inter = Inter({ subsets: ["latin"] });
 const roboto = Roboto({ subsets: ["latin"], weight: ['400', '500', '700'] });
@@ -13,6 +14,20 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <Script
+          async
+          src="https://www.googletagmanager.com/gtag/js?id=G-EQMY1YEC95"
+        ></Script>
+        <Script id="google-analytics">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-LL85JFDCVV');
+          `}
+        </Script>
+      </head>
       <Head>
         <title>Rustcrab - The Non-Crap Repo for Rust Developers</title>
         <meta name="description" content="The best repository for Rust developers" />


### PR DESCRIPTION
**Fixes** #1 

For Adding `Google Analytics` to `rustcrab.com`, we need to have set up [Google Analytic Account ](https://analytics.google.com/analytics/web/?authuser=0#/provision/SignUp)

1. Set up an account in **GA** and add `rustcrab.com` in data stream.
<img width="1141" alt="Screenshot 2024-07-12 at 9 55 26 PM" src="https://github.com/user-attachments/assets/a8384148-4881-468c-bc4c-1f35fc40f14f">



2. Set up a `google tag` after the above step

<img width="1033" alt="Screenshot 2024-07-12 at 9 56 05 PM" src="https://github.com/user-attachments/assets/5166045f-553f-4493-bb00-1b1b4a27bd59">

Add tag value inside the Script in **[#line18](https://github.com/FrancescoXX/rustcrab/pull/21/files#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R18-R29)**

- Just click on test and that would be good to go. 

To ensure Google Analytics has added properly to the website, just test whether `gtag` is available in console whether in production or locally.

<details><summary>More Info</summary>
<p>
<img width="367" alt="Screenshot 2024-07-12 at 9 48 40 PM" src="https://github.com/user-attachments/assets/f3dc0205-3653-4797-a7a9-da6d93a90215">
</p>
</details> 







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Integrated Google Analytics for enhanced tracking and analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->