### PR TITLE
Bug #93 Fixed Buttons order and Copied code message

### DIFF
--- a/src/app/dsas/page.tsx
+++ b/src/app/dsas/page.tsx
@@ -110,16 +110,16 @@ const DSAPage: React.FC = () => {
             </pre>
 
             <button
-              onClick={handleCloseModal}
-              className="mt-4 ml-4 bg-red-500 hover:bg-red-600 text-white font-semibold py-2 px-4 rounded-full transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-opacity-50"
-            >
-              Close
-            </button>
-            <button
               onClick={handleCopyCode}
               className="mt-4 bg-green-500 hover:bg-green-600 text-white font-semibold py-2 px-4 rounded-full transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-opacity-50"
             >
               Copy Code
+            </button>
+            <button
+              onClick={handleCloseModal}
+              className="mt-4 ml-4 bg-red-500 hover:bg-red-600 text-white font-semibold py-2 px-4 rounded-full transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-opacity-50"
+            >
+              Close
             </button>
             {copySuccess && (
               <p className="mt-2 text-sm text-green-500">{copySuccess}</p>

--- a/src/components/DSASection.tsx
+++ b/src/components/DSASection.tsx
@@ -82,15 +82,15 @@ const DSAToolSection: React.FC = () => {
             >
               Copy Code
             </button>
-            {copySuccess && (
-              <p className="mt-2 text-sm text-green-500">{copySuccess}</p>
-            )}
             <button
               onClick={handleCloseModal}
               className="mt-4 bg-red-500 hover:bg-red-600 text-white font-semibold py-2 px-4 rounded-full transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-opacity-50"
-            >
+              >
               Close
             </button>
+              {copySuccess && (
+                <p className="mt-2 text-sm text-green-500">{copySuccess}</p>
+              )}
           </div>
         </div>
       )}


### PR DESCRIPTION
# Description
The issue which were fixed are 
- The buttons ordering. In the DSA Examples page the buttons were in the order of Copy Code then Close. Whereas in the Show More page they were in the order Close and Copy Code. This ordering issue was fixed.
- And in the DSA Exmples page when i click on copy code the message was shown in between of two buttons whereas in the Show more page it was showing below the both buttons. This was fixed.


Fixes # (issue) #93 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Swapped the positions of the "Close" button and the "Copy Code" button for better user experience.
	- Added a success message that displays after clicking the "Copy Code" button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->