### PR TITLE
#109 Centered the Copyright text

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -56,20 +56,21 @@ export default function Footer() {
         >
           <FaThreads />
         </a>
-        <div className='text-white sm:flex sm:items-center sm:justify-center gap-3'>
-     <span className='sm:text-center gap-2 lg:flex lg:items-center lg:justify-center sm:block md:flex'>
-      <p className='gap-2'>
-        &copy; {currentYear}
-      </p>
-      <Link href="https://app.daily.dev/squads/rustdevs" className='hover:underline'>
-        Rustcrab
-      </Link>
-      <p>
-        All Rights Reserved.
-      </p>
-     </span>
-     </div>
       </div>
-     
+      <div className='text-white sm:flex sm:items-center sm:justify-center gap-3'>
+        <span className='sm:text-center gap-2 lg:flex lg:items-center lg:justify-center sm:block md:flex text-xs'>
+          <p className='gap-2'>
+            &copy; {currentYear}
+          </p>
+          <Link href="https://app.daily.dev/squads/rustdevs" className='hover:underline'>
+            Rustcrab
+          </Link>
+          <p>
+            All Rights Reserved.
+          </p>
+        </span>
+      </div>
+
     </footer>
-  )}
+  )
+}


### PR DESCRIPTION
# Description

The copyright text was centered by moving it to the new line.

Fixes # (issue): #109 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the visual layout and presentation of the footer section by adjusting the positioning and alignment of text and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->