### PR TITLE
copyright text alignment

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -56,20 +56,22 @@ export default function Footer() {
         >
           <FaThreads />
         </a>
-        <div className='text-white sm:flex sm:items-center sm:justify-center gap-3'>
-     <span className='sm:text-center gap-2 lg:flex lg:items-center lg:justify-center sm:block md:flex'>
-      <p className='gap-2'>
-        &copy; {currentYear}
-      </p>
-      <Link href="https://app.daily.dev/squads/rustdevs" className='hover:underline'>
-        Rustcrab
-      </Link>
-      <p>
-        All Rights Reserved.
-      </p>
-     </span>
-     </div>
-      </div>
+        </div>
+        <div className='text-white text-sm sm:flex sm:items-center sm:justify-center gap-3 whitespace-nowrap'>
+  <div className='sm:text-center text-center gap-2 lg:flex lg:items-center lg:justify-center sm:flex md:flex'>
+    <p className='gap-2'>
+      &copy; {currentYear}
+    </p>
+    <Link href="https://app.daily.dev/squads/rustdevs" className='hover:underline'>
+      Rustcrab
+    </Link>
+    <p>
+      All Rights Reserved.
+    </p>
+  </div>
+</div>
+
+     
      
     </footer>
   )}


### PR DESCRIPTION
# Description

Moved copyright text to the new line and made text size a bit small

Fixes # (issue): #109 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the structure and styling of the footer for improved visual layout and organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->