### PR TITLE
#113 Fix : Copyright is not visible in Light Mode

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -57,7 +57,7 @@ export default function Footer() {
           <FaThreads />
         </a>
       </div>
-      <div className='text-white sm:flex sm:items-center sm:justify-center gap-3'>
+      <div className='text-black dark:text-white sm:flex sm:items-center sm:justify-center gap-3'>
         <span className='sm:text-center gap-2 lg:flex lg:items-center lg:justify-center sm:block md:flex text-xs'>
           <p className='gap-2'>
             &copy; {currentYear}


### PR DESCRIPTION
# Description

Fixed issue with the footer theme when switched from dark to light it does not seems to be visible.

Fixes # (issue)

## (#113 ) 

# Test Required (Yes / No)
No

**Test Configuration**:
* Platform: Linux
* Architecture: Amd-x64
* Version: 24.04-LTS


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated text color in the footer to adapt to light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->