### PR TITLE
bugfix:Navigation issue in Mobile fixed

### DIFF
--- a/src/components/navbar/MobileNav.tsx
+++ b/src/components/navbar/MobileNav.tsx
@@ -11,12 +11,12 @@ interface menuObject {
 
 export const menuItems: menuObject[] = [
   { items: 'Home', link: '/' },
-  { items: 'Books', link: '#books' },
-  { items: 'Projects', link: '#projects' },
-  { items: 'Dev Tools', link: '#dev_tools' },
-  { items: 'Lesson', link: '#lesson' },
-  { items: 'People', link: '#people' },
-  { items: 'DSA', link: '#dsa' }
+  { items: 'Books', link: '/#books' },
+  { items: 'Projects', link: '/#projects' },
+  { items: 'Dev Tools', link: '/#dev_tools' },
+  { items: 'Lesson', link: '/#lessons' },
+  { items: 'People', link: '/#people' },
+  { items: 'DSA', link: '/#dsas' }
 ];
 
 const MobileNav: React.FC = () => {


### PR DESCRIPTION
# Description

 Bug fixed Unable to navigate to DSA and Lessons from the Navbar Mobile.

Fixes # ([issue](https://github.com/FrancescoXX/rustcrab/issues/131))

## please go through the screenshots 

https://github.com/user-attachments/assets/e332a194-ea95-4169-a920-ab1bd5195e97




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated navigation links in the mobile menu to correctly point to their respective sections on the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->