### PR TITLE
add margin to top of section for DevTools and Books section

### DIFF
--- a/src/components/BooksSection.tsx
+++ b/src/components/BooksSection.tsx
@@ -4,11 +4,11 @@ import Card from "./Card";
 
 export default function BooksSection() {
   return (
-    <section className="py-16 pt-10  rounded-md my-4">
-      <div className="mx-auto px-4 container">
-        <h2 className="text-4xl font-bold mb-8 text-center text-current">
-          Books to Learn Rust
-        </h2>
+    <section className="py-16 w-full rounded-md my-4">
+    <div className="container mx-auto px-4">
+      <h2 className="text-4xl font-bold mb-8 text-center text-current">
+      Books to Learn Rust
+      </h2>
         <div className="grid md:grid-cols-2 w-full gap-5">
           {books.slice(0, 3).map((book, index) => (
             <Card item={book} key={index} />

--- a/src/components/DevToolsSection.tsx
+++ b/src/components/DevToolsSection.tsx
@@ -4,11 +4,11 @@ import Card from "./Card";
 
 export default function DevToolsSection() {
   return (
-    <section className="min-h-dvh pt-10  rounded-md my-4">
-      <div className="mx-auto px-4 container">
-        <h2 className="text-4xl font-bold mb-8 text-center text-current">
-          Rust Developer Tools
-        </h2>
+    <section className="py-16 w-full rounded-md my-4">
+    <div className="container mx-auto px-4">
+      <h2 className="text-4xl font-bold mb-8 text-center text-current">
+      Rust Developer Tools
+      </h2>
         <div className="grid md:grid-cols-3 w-full gap-5">
           {tools.slice(0, 3).map((tool, index) => (
             <Card item={tool} key={index} />


### PR DESCRIPTION
**Description**

Books and Dev Tools headings are not in the same position as the rest of the headings

**Expected Behavior**

Should be :

![New_books](https://github.com/user-attachments/assets/917e311d-cccd-4b65-854c-dc4a852d238d)


**Actual Behavior**

![heading_books](https://github.com/user-attachments/assets/0083097f-0fb4-4410-94f5-aedd3c75f506)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced layout and styling of the Books and DevTools sections for improved responsiveness.

- **Bug Fixes**
  - Adjusted class names to ensure consistent styling and presentation across components.

- **Style**
  - Updated class configurations for better visual alignment and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->