### PR TITLE
fix: #157

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -52,7 +52,7 @@ export default function Header() {
 
   return (
     <header
-      className={`flex justify-between items-center p-4 space-x-4 sticky top-0 border-b-2 0 z-40 ${
+      className={`flex justify-between items-center md:p-4 p-4 space-x-4 sticky top-0 border-b-2 0 z-40 sm:pl-0 ${
         isScrolled
           ? "backdrop-blur-md bg-opacity-70 bg-transparent"
           : "bg-white dark:bg-black"
@@ -64,7 +64,7 @@ export default function Header() {
         </div>
         <Link
           href="/"
-          className="text-2xl font-bold cursor-pointer hidden sm:block"
+          className="text-2xl md:text-2xl font-bold cursor-pointer hidden sm:block sm:text-base"
         >
           Rustcrab
         </Link>

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -18,7 +18,7 @@ const menuItems = [
 
 const Navbar: React.FC = () => {
   return (
-    <ul className="flex space-x-4 small-medium:space-x-2 capitalize">
+    <ul className="flex space-x-4 small-medium:space-x-2 capitalize md:text-base text-base sm:text-sm">
       {menuItems.map((item, index) => (
         <Link href={item.link} key={index} className="cursor-pointer transition ease-in-out">
           <span className="hover:text-orange-500">{item.items}</span>


### PR DESCRIPTION
# Description

I've fixed Navbar Styling Issue on Homepage on meduim size (640 to 760) #157 
with changing links font size 
now Text is vertically centered and menu items are evenly spaced.Fixes # (issue)

// It is my first time contributing to open sources and I'll be glad if you accept my work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the responsiveness of the header and navbar components for improved usability across different devices.
- **Style**
	- Updated CSS class names in the header and navbar to optimize text size and padding for various screen sizes, ensuring better readability and visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->